### PR TITLE
Add Custom Cooldown & Exempt User Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Simple Discord bot wrapper for Minimap Renderer.
 
   
 
-1. Get Python 3.10 or higher 
+1. Get Python 3.10 or higher
 
   
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Simple Discord bot wrapper for Minimap Renderer.
 
   
 
-1. Get Python 3.10 or higher
+1. Get Python 3.10 or higher 
 
   
 
@@ -48,8 +48,14 @@ REDIS_HOST=YOUR_REDIS_HOST
 REDIS_PORT=YOUR_REDIS_PORT
 REDIS_USERNAME=YOUR_REDIS_USERNAME
 REDIS_PASSWORD=YOUR_REDIS_PASSWORD
+COOLDOWN_TIMER=60
+CD_EXEMPT_USERS='[""]'
 ```
-
+`COOLDOWN_TIMER` can be changed to tweak the cooldown timer that each user must undergo in s, by default it's set to 60, you can lower it if you only have a few users 
+or else raise it if you have many.
+`CD_EXEMPT_USERS` can be modified to include the Discord User IDs of certain users, such that they bypass the cooldown timer entirely. Additional users can be added like so:
+`CD_EXEMPT_USERS='["123456789012345678","876543210987654321"]'` assuming that `123456789012345678` and `876543210987654321` are the Discord User IDs of two people you want to be exempt. 
+You can have as many as you like.
   
  
 ### Usage

--- a/tasks/single.py
+++ b/tasks/single.py
@@ -51,7 +51,7 @@ def render_single(
     except Exception as e:
         return e
     finally:
-        CDE = environ.get("CD_EXEMPT_USERS")
+        CDE = environ.get("CD_EXEMPT_USERS",["1234567890"])
         CDT = int(environ.get("COOLDOWN_TIMER",60))
         if str(user_id) not in CDE:
             REDIS.set(f"cooldown_{user_id}", "", ex=CDT)

--- a/tasks/single.py
+++ b/tasks/single.py
@@ -8,7 +8,7 @@ from tempfile import NamedTemporaryFile
 from utils.exceptions import ReplayParsingError, ReplayRenderingError
 from utils.connection import REDIS
 from utils.logging import LOGGER
-
+from os import environ
 
 def render_single(
     user_id: int,
@@ -51,4 +51,8 @@ def render_single(
     except Exception as e:
         return e
     finally:
-        REDIS.set(f"cooldown_{user_id}", "", ex=60)
+        CDE = environ.get("CD_EXEMPT_USERS")
+        CDT = int(environ.get("COOLDOWN_TIMER",60))
+        if str(user_id) not in CDE:
+            REDIS.set(f"cooldown_{user_id}", "", ex=CDT)
+


### PR DESCRIPTION
This is a pretty small change that keeps the "minimalist" idea but also gives room for a tad bit more customization without having to hardcode. This adds two additional variables to the .env file, `COOLDOWN_TIMER` and `CD_EXEMPT_USERS`, and then it makes a few changes to `single.py` to set the cooldown to the value in the .env file, and allows those specified by user_id in `CD_EXEMPT_USERS` to be exempt from the cooldown, and accounts for it being left as the boilerplate by adding a list of one `["1234567890"]` as the backup when loading the variables, allowing it to function even if the .env file is left as is in the readme, `'[""]'`.

README updated accordingly.