### PR TITLE
Pull Request to add two simple features - ability to change cooldown length and exempt users via the .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ git clone https://github.com/WoWs-Builder-Team/minimap_renderer_bot.git
   
 
 3. Install dependencies
-Depending on preferences, once you've entereted the minimap_renderer_bot directory you would [activate the virtual environment.](https://docs.python.org/3/library/venv.html) 
+
+Depending on preferences, once you've entereted the `minimap_renderer_bot` directory you would create (as explained above) and then [activate the virtual environment.](https://docs.python.org/3/library/venv.html) 
 
 
 ```
@@ -58,7 +59,7 @@ and a list of users you would like to be exempt from the cooldown altogether, us
  
 ### Usage
 
-  
+Ensure that if you created a virtual environment that you have it activated.
 
 To start the bot
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ git clone https://github.com/WoWs-Builder-Team/minimap_renderer_bot.git
   
 
 3. Install dependencies
+Depending on preferences, once you've entereted the minimap_renderer_bot directory you would [activate the virtual environment.](https://docs.python.org/3/library/venv.html) 
 
-  
 
 ```
 cd minimap_renderer_bot
@@ -38,7 +38,7 @@ pip install git+https://github.com/WoWs-Builder-Team/minimap_renderer.git@develo
 pip install -U -r requirements.txt
 ```
 
-  
+
 
 4. Create a `.env` file. **(Important)**
 
@@ -48,8 +48,12 @@ REDIS_HOST=YOUR_REDIS_HOST
 REDIS_PORT=YOUR_REDIS_PORT
 REDIS_USERNAME=YOUR_REDIS_USERNAME
 REDIS_PASSWORD=YOUR_REDIS_PASSWORD
+COOLDOWN_TIMER=60
+CD_EXEMPT_USERS='[""]'
 ```
 
+The final two are related to the cooldown each user gets between /render commmands, 
+and a list of users you would like to be exempt from the cooldown altogether, using their Discord User IDs.
   
  
 ### Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,4 @@ tqdm==4.64.0
 typing_extensions==4.3.0
 wrapt==1.14.1
 yarl==1.8.1
+python-dotenv==1.0.0

--- a/tasks/single.py
+++ b/tasks/single.py
@@ -8,8 +8,11 @@ from tempfile import NamedTemporaryFile
 from utils.exceptions import ReplayParsingError, ReplayRenderingError
 from utils.connection import REDIS
 from utils.logging import LOGGER
+from os import environ
+from dotenv import load_dotenv
 
 
+load_dotenv()
 def render_single(
     user_id: int,
     replay_bytes: bytes,
@@ -51,4 +54,11 @@ def render_single(
     except Exception as e:
         return e
     finally:
-        REDIS.set(f"cooldown_{user_id}", "", ex=60)
+
+        CDE = environ.get("CD_EXEMPT_USERS")
+        CDT = int(environ.get("COOLDOWN_TIMER"))
+        if CDT == None:
+            CDT = 60
+        if str(user_id) in CDE:
+            CDT = 1
+        REDIS.set(f"cooldown_{user_id}", "", ex=CDT)


### PR DESCRIPTION
This is a relatively simple change in which `.env` has two additional entries, `COOLDOWN_TIMER` which just defines the cooldown, and `CD_EXEMPT_USERS` which is a list of users that are exempt from the cooldown (it actually sets it to 1 second, but, practically none) using their Discord User IDs. 

This involved a few lines added to `single.py` to create the functionality and updating the README to reflect it, and added a few lines on the README about when to create and activate the virtual environment if they are using it, along with a link to documentation for venv.

I've tested it pretty extensively, and it keeps with the minimalist design of this bot while allowing a few additional simple features.